### PR TITLE
[GOBBLIN-1685] Implement Helix dynamic workunit FileSystemMessageBuffer

### DIFF
--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/messaging/DynamicWorkUnitConfigKeys.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/messaging/DynamicWorkUnitConfigKeys.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.runtime.messaging;
+
+public class DynamicWorkUnitConfigKeys {
+  public static final String DYNAMIC_WORKUNIT_PREFIX = "gobblin.dynamic.workunit.";
+
+  public static final String DYNAMIC_WORKUNIT_HDFS_PREFIX = DYNAMIC_WORKUNIT_PREFIX + "hdfs.";
+
+  public static final String DYNAMIC_WORKUNIT_HDFS_PATH = DYNAMIC_WORKUNIT_HDFS_PREFIX + "path";
+  public static final String DYNAMIC_WORKUNIT_HDFS_POLLING_RATE_MILLIS = DYNAMIC_WORKUNIT_HDFS_PREFIX + "pollingRate";
+  public static final long DYNAMIC_WORKUNIT_HDFS_DEFAULT_POLLING_RATE = 30000;
+
+}

--- a/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/messaging/hdfs/FileSystemMessageBuffer.java
+++ b/gobblin-runtime/src/main/java/org/apache/gobblin/runtime/messaging/hdfs/FileSystemMessageBuffer.java
@@ -16,47 +16,74 @@
  */
 package org.apache.gobblin.runtime.messaging.hdfs;
 
+import com.google.common.io.ByteStreams;
 import com.typesafe.config.Config;
+
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.gobblin.runtime.messaging.MessageBuffer;
 import org.apache.gobblin.runtime.messaging.data.DynamicWorkUnitMessage;
 import org.apache.gobblin.runtime.messaging.data.DynamicWorkUnitSerde;
+import org.apache.gobblin.util.ConfigUtils;
+import org.apache.gobblin.util.PathUtils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+
+import static org.apache.gobblin.runtime.messaging.DynamicWorkUnitConfigKeys.*;
 
 
 /**
  * Implements {@link FileSystem} based message buffer for sending and receiving {@link DynamicWorkUnitMessage}.
  */
+@Slf4j
 public class FileSystemMessageBuffer implements MessageBuffer<DynamicWorkUnitMessage> {
+
+  // Dynamic Workunit message specific file suffix
+  private static final String messageFileSuffix = ".wumessage";
+
   private boolean isPollingTaskScheduled = false;
 
   @Getter
   private final String channelName;
   private final FileSystem fs;
-  private final Path dir;
+  @Getter
+  private final Path path;
   private final long pollingRateMillis;
   private final List<Consumer<List<DynamicWorkUnitMessage>>> subscribers = new ArrayList<>();
 
-  public FileSystemMessageBuffer(FileSystem fs, String channelName, long pollingRateMillis, Path parentWorkingDir) {
+  private FileSystemMessageBuffer(FileSystem fs, String channelName, long pollingRateMillis, Path parentWorkingDir) {
     this.fs = fs;
     this.channelName = channelName;
     this.pollingRateMillis = pollingRateMillis;
-    this.dir = Path.mergePaths(parentWorkingDir, new Path(channelName));
+    this.path = parentWorkingDir;
   }
 
   @Override
   public void publish(DynamicWorkUnitMessage item) throws IOException {
     byte[] serializedMsg = DynamicWorkUnitSerde.serialize(item);
-    persistMessage(serializedMsg);
+    try (FSDataOutputStream os = fs.create(this.getFilePathForMessage(item), true)) {
+      os.write(serializedMsg);
+      log.info("Persisted message into HDFS path {} for workunit {}.", path.toString(), item.getWorkUnitId());
+    } catch (IOException ioException) {
+      log.error("Failed to persist message into HDFS path {} for workunit {}.",
+          path.toString(), item.getWorkUnitId(), ioException);
+      throw ioException;
+    }
   }
 
   @Override
@@ -86,38 +113,68 @@ public class FileSystemMessageBuffer implements MessageBuffer<DynamicWorkUnitMes
   }
 
   private List<DynamicWorkUnitMessage> getNewMessages() {
-    // STUB: TODO GOBBLIN-1685 Read all files in dir, deserialize, then clean up byte files in dir
-    return null;
+    List<DynamicWorkUnitMessage> messageList = new LinkedList<>();
+    try {
+      FileStatus[] fileStatus = fs.listStatus(path);
+      for(FileStatus status : fileStatus){
+        Path singlePath = status.getPath();
+        if (fs.isFile(singlePath))
+        {
+          FSDataInputStream fis = fs.open(singlePath);
+          DynamicWorkUnitMessage message = DynamicWorkUnitSerde.deserialize(ByteStreams.toByteArray(fis));
+          messageList.add(message);
+          fs.delete(singlePath, true);
+          log.debug("Fetched message from HDFS path {}.", singlePath.toString());
+        }
+      }
+    } catch (IOException ioException) {
+      log.error("Failed to get message from HDFS path {}.", path.toString(), ioException);
+    }
+
+    return messageList;
   }
 
-  private void persistMessage(byte[] serializeMsg) throws IOException {
-    // STUB: TODO GOBBLIN-1685 write serialized message to FileSystem
+  private Path getFilePathForMessage(DynamicWorkUnitMessage message) {
+    String messageFileName = message.getWorkUnitId() + "_" + System.currentTimeMillis();
+    Path messagePath = PathUtils.mergePaths(path, new Path(messageFileName));
+    return PathUtils.addExtension(messagePath, messageFileSuffix);
   }
 
   public static class Factory implements MessageBuffer.Factory<DynamicWorkUnitMessage> {
     private static volatile ScheduledExecutorService executorSingleton;
-    private Config cfg;
+    private final Config cfg;
+    private Path basePath;
+    private FileSystem fileSystem;
+    private long pollingRate;
     public Factory(Config cfg) {
-      // STUB: TODO GOBBLIN-1685 Add any necessary setup
       this.cfg = cfg;
+      this.setup();
     }
 
     @Override
     public MessageBuffer<DynamicWorkUnitMessage> getBuffer(String channelName) {
-      // STUB: TODO GOBBLIN-1685 Construct buffer object based on Typesafe Config
-      return null;
+      Path workunitPath = new Path(basePath, channelName);
+      log.info("HDFS directory for dynamic workunit is: " + workunitPath);
+
+      return new FileSystemMessageBuffer(fileSystem, channelName, pollingRate, workunitPath);
     }
 
-    private FileSystem getFileSystem(Config cfg) {
-      // STUB: TODO GOBBLIN-1685 Get filesystem based on current state
-      return null;
+    private void setup() {
+      String fsPathString = this.cfg.getString(DYNAMIC_WORKUNIT_HDFS_PATH);
+      this.basePath = new Path(fsPathString);
+      try {
+        this.fileSystem = this.basePath.getFileSystem(new Configuration());
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to detect workunit directory file system:", e);
+      }
+      pollingRate = ConfigUtils.getLong(this.cfg, DYNAMIC_WORKUNIT_HDFS_POLLING_RATE_MILLIS,
+          DYNAMIC_WORKUNIT_HDFS_DEFAULT_POLLING_RATE);
     }
 
     private synchronized static ScheduledExecutorService getExecutorInstance() {
       if (executorSingleton == null) {
         executorSingleton = Executors.newScheduledThreadPool(1);
       }
-
       return executorSingleton;
     }
   }

--- a/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/messaging/data/FileSystemMessageBufferTest.java
+++ b/gobblin-runtime/src/test/java/org/apache/gobblin/runtime/messaging/data/FileSystemMessageBufferTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gobblin.runtime.messaging.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Files;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import org.apache.gobblin.runtime.messaging.DynamicWorkUnitConsumer;
+import org.apache.gobblin.runtime.messaging.hdfs.FileSystemMessageBuffer;
+
+import static org.apache.gobblin.runtime.messaging.DynamicWorkUnitConfigKeys.DYNAMIC_WORKUNIT_HDFS_PATH;
+import static org.apache.gobblin.runtime.messaging.DynamicWorkUnitConfigKeys.DYNAMIC_WORKUNIT_HDFS_POLLING_RATE_MILLIS;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+
+
+public class FileSystemMessageBufferTest {
+
+  FileSystemMessageBuffer messageBuffer;
+  FileSystem fs;
+  File baseDir;
+  Path path;
+
+  @BeforeClass
+  public void testConstructBuffer()
+      throws IOException {
+    baseDir = Files.createTempDir();
+    this.fs = FileSystem.get(baseDir.toURI(), new Configuration());
+    Config cfg = ConfigFactory.empty()
+        .withValue(DYNAMIC_WORKUNIT_HDFS_PATH, ConfigValueFactory.fromAnyRef(baseDir.getAbsolutePath()))
+        .withValue(DYNAMIC_WORKUNIT_HDFS_POLLING_RATE_MILLIS, ConfigValueFactory.fromAnyRef(500));
+    FileSystemMessageBuffer.Factory factory = new FileSystemMessageBuffer.Factory(cfg);
+    messageBuffer = (FileSystemMessageBuffer) factory.getBuffer("HDFS_channel");
+    path = messageBuffer.getPath();
+
+  }
+
+  @Test
+  public void testPublish() throws IOException {
+    String workUnitId = "workUnit0";
+    List<String> laggingPartitions = new ArrayList<>(Arrays.asList("partition-0","partition-1"));
+    SplitWorkUnitMessage splitMessage = new SplitWorkUnitMessage(workUnitId, laggingPartitions);
+
+    messageBuffer.publish(splitMessage);
+    fs.exists(path);
+    FileStatus[] fileStatus = fs.listStatus(path);
+    Assert.assertEquals(fileStatus.length, 1);
+    FSDataInputStream fis = fs.open(fileStatus[0].getPath());
+    DynamicWorkUnitMessage message = DynamicWorkUnitSerde.deserialize(ByteStreams.toByteArray(fis));
+
+    Assert.assertEquals(message.getWorkUnitId(), workUnitId);
+    Assert.assertEquals(((SplitWorkUnitMessage) message).getLaggingTopicPartitions().size(), 2);
+
+  }
+
+  @Test (dependsOnMethods={"testPublish"})
+  public void testSubscribe() throws IOException, InterruptedException {
+    DynamicWorkUnitConsumer consumer = Mockito.mock(DynamicWorkUnitConsumer.class);
+
+    messageBuffer.subscribe(consumer);
+    Thread.sleep(1000);
+    Mockito.verify(consumer, times(1)).accept(any(List.class));
+
+    // After reading all messages in the path, files should be cleaned up
+    Assert.assertEquals(fs.listStatus(path).length, 0);
+
+  }
+
+  @AfterClass
+  public void cleanup() throws IOException {
+    fs.delete(new Path(baseDir.getPath()), true);
+  }
+
+}


### PR DESCRIPTION
Dear Gobblin maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [ ] My PR addresses the following [Gobblin JIRA](https://issues.apache.org/jira/browse/GOBBLIN/) issues and references them in the PR title. For example, "[GOBBLIN-1685] My Gobblin PR"
    - https://issues.apache.org/jira/browse/GOBBLIN-1685


### Description
- [ ] Here are some details about my PR, including screenshots (if applicable):
Implementation of FileSystemMessageBuffer that can:
write a JsonElement to a given path
read all JsonElements in a given path, and delete after retrieving 

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added test cases

### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

